### PR TITLE
Fix future warning with numpy 1.14.0

### DIFF
--- a/nems/tentbasis.py
+++ b/nems/tentbasis.py
@@ -55,7 +55,7 @@ class Nonlinearity:
         Estimate parameters (using a least squares fit) to approximate f(x) = y
         """
         Phi = self(x)[0]
-        return np.linalg.lstsq(Phi, y)[0]
+        return np.linalg.lstsq(Phi, y, rcond=-1)[0]
 
     def plot(self, weights, ax=None, num_samples=1000, color='black'):
         """


### PR DESCRIPTION
Since numpy 1.14.0 the use of `numpy.linalg.lstsq` gives a future warning if the optional parameter `rcond` is not explicitly set (see [numpy documentation](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.lstsq.html)).

This change here just adds this missing parameter in *tentbasis.py* to preserve the original behavior.

