### PR TITLE
Allow selection of spatial axis for visualization

### DIFF
--- a/nems/models.py
+++ b/nems/models.py
@@ -267,8 +267,8 @@ class NeuralEncodingModel(object):
 
         return results
 
-    def plot(self):
-        visualization.plot(self)
+    def plot(self, axis=0):
+        visualization.plot(self, axis=axis)
 
     def kfold(self, nfolds, *args, **kwargs):
         kf = KFold(len(self.data), n_folds=nfolds, shuffle=True)

--- a/nems/visualization.py
+++ b/nems/visualization.py
@@ -30,7 +30,7 @@ def contour(W, n=3, **kwargs):
     plt.contour(-W, n, **kwargs)
 
 
-def plot(mdl, cmap='seismic'):
+def plot(mdl, cmap='seismic', axis=0):
     """
     Plots the parameters of a NeuralEncodingModel
 
@@ -46,6 +46,20 @@ def plot(mdl, cmap='seismic'):
     # Plot the filters.
     for j in range(nsub):
         W = mdl.theta['W'][j]
+
+        # Reshape filter if three dimensional.
+        if len(mdl.filter_dims) > 2:
+            W = W.reshape(mdl.filter_dims)
+            assert axis == 0 or axis == 1, "Invalid spatial axis"
+
+            # Get maximum intensity value from the other spatial axis.
+            W = np.rollaxis(W, 1-axis)
+            maxi = np.unravel_index(np.abs(W).argmax(),
+                                    mdl.filter_dims)[0]
+
+            # Discard the other spatial axis.
+            W = W[maxi]
+
         ax = fig.add_subplot(2, nsub, j + 1)
         ax.pcolor(W, cmap=cm.__dict__[cmap], vmin=-maxval, vmax=maxval)
         ax.set_xticks([])


### PR DESCRIPTION
If training a model with more than one spatial dimension, the visualization of the linear filter (space against time) does not produce recognizable results.

These changes allow to select the spatial dimension to plot against, while preserving previous behavior as this is implemented with optional parameters.